### PR TITLE
adds an indent directory and sources groovy indentation rules

### DIFF
--- a/indent/Jenkinsfile.vim
+++ b/indent/Jenkinsfile.vim
@@ -1,0 +1,1 @@
+runtime indent/groovy.vim


### PR DESCRIPTION
This pull request adds the `Jenkinsfile-vim-syntax/indent` directory to contain indent rules for the plugin.  In `Jenkinsfile-vim-syntax/indent/Jenkinsfile.vim` we source the `indent/groovy.vim` file to allow groovy syntax indentation with `gg=G`.