### PR TITLE
Add upper case extension to matched files

### DIFF
--- a/ftdetect/Jenkinsfile.vim
+++ b/ftdetect/Jenkinsfile.vim
@@ -3,3 +3,4 @@ autocmd BufRead,BufNewFile Jenkinsfile set ft=Jenkinsfile
 autocmd BufRead,BufNewFile Jenkinsfile* setf Jenkinsfile
 autocmd BufRead,BufNewFile *.jenkinsfile set ft=Jenkinsfile
 autocmd BufRead,BufNewFile *.jenkinsfile setf Jenkinsfile
+autocmd BufRead,BufNewFile *.Jenkinsfile setf Jenkinsfile


### PR DESCRIPTION
A small change to allow upper cased extensions to be picked up

I'm aware this isn't ideal, and extensions should be lower case but its not an uncommon mistake, and this is handled gracefully in both IDEA IDEs and VS Code Jenkinsfile extensions.