### PR TITLE
Made filetype matching a bit more flexible

### DIFF
--- a/ftdetect/Jenkinsfile.vim
+++ b/ftdetect/Jenkinsfile.vim
@@ -1,6 +1,6 @@
 " Jenkinsfile
-autocmd BufRead,BufNewFile Jenkinsfile set ft=Jenkinsfile
-autocmd BufRead,BufNewFile Jenkinsfile* setf Jenkinsfile
-autocmd BufRead,BufNewFile *.jenkinsfile set ft=Jenkinsfile
-autocmd BufRead,BufNewFile *.jenkinsfile setf Jenkinsfile
-autocmd BufRead,BufNewFile *.Jenkinsfile setf Jenkinsfile
+
+augroup JenkinsAUGroup
+  autocmd BufRead,BufNewFile *Jenkins* set ft=Jenkinsfile
+  autocmd BufRead,BufNewFile *jenkins* set ft=Jenkinsfile
+augroup END


### PR DESCRIPTION
Where I work we have jenkinsfiles `JenkinsFile` and `JenkinsDeploy` which the current ftdetect won't match. Really like this plugin, this will make it more useful (for me at least).