### PR TITLE
Revert "Made filetype matching a bit more flexible"

### DIFF
--- a/ftdetect/Jenkinsfile.vim
+++ b/ftdetect/Jenkinsfile.vim
@@ -1,6 +1,6 @@
 " Jenkinsfile
-
-augroup JenkinsAUGroup
-  autocmd BufRead,BufNewFile *Jenkins* set ft=Jenkinsfile
-  autocmd BufRead,BufNewFile *jenkins* set ft=Jenkinsfile
-augroup END
+autocmd BufRead,BufNewFile Jenkinsfile set ft=Jenkinsfile
+autocmd BufRead,BufNewFile Jenkinsfile* setf Jenkinsfile
+autocmd BufRead,BufNewFile *.jenkinsfile set ft=Jenkinsfile
+autocmd BufRead,BufNewFile *.jenkinsfile setf Jenkinsfile
+autocmd BufRead,BufNewFile *.Jenkinsfile setf Jenkinsfile


### PR DESCRIPTION
Sorry to introduce churn.  However, this PR is necessary to fix fairly significant unintended behavior.

This reverts commit 289d104758fa3a95fdba201832510d5a7c81c8d9, merged to https://github.com/martinda/Jenkinsfile-vim-syntax in #12.

Unfortunately, #12 makes filetype matching a bit too flexible.  It breaks filetype detection for non-Jenkinsfile files whose names contain the string "jenkins".  For example, it forces the filetype of
`ftdetect/Jenkinsfile.vim` to be detected as `Jenkinsfile` instead of `vim`.  If I made a file called `jenkins-deployment-readme.md`, it would also be detected as `Jenkinsfile` instead of `markdown`.  This is pretty bad.

Vim already includes multiple mechanisms to detect nonstandard filenames as Jenkinsfiles:

- Add a custom `autocmd` group to the local `.vimrc`.
- Add a Vim [modeline](https://vim.fandom.com/wiki/Modeline_magic) to the file itself.  The original use case for #12 was to add filetype detection for a file called `JenkinsDeploy`.  Appending the following modeline to the end of the file would force correct filetype detection:
    ```groovy
    // vim: set ft=Jenkinsfile
    ```

Updating a public plugin to accommodate local nonstandard behavior is problematic, as it breaks functionality for all plugin users.