### PR TITLE
More syntax directives

### DIFF
--- a/syntax/Jenkinsfile.vim
+++ b/syntax/Jenkinsfile.vim
@@ -1,7 +1,7 @@
 runtime syntax/groovy.vim
 syn keyword jenkinsfileBuiltInVariable currentBuild
 
-syn keyword jenkinsfileSection pipeline agent stages steps
+syn keyword jenkinsfileSection pipeline agent stages steps post
 
 syn keyword jenkinsfileDirective environment options parameters triggers stage tools input when libraries
 
@@ -11,7 +11,7 @@ syn region  jenkinsfileOptionParams contained start='(' end=')' transparent cont
 syn match   jenkinsfileOptionO /[a-zA-Z]\+([^)]*)/ contains=jenkinsfileOption,jenkinsfileOptionParams transparent containedin=groovyParenT1
 
 syn keyword jenkinsfileCoreStep checkout
-syn keyword jenkinsfileCoreStep docker skipwhite nextgroup=jenkinsFileDockerConfigBlock
+syn keyword jenkinsfileCoreStep docker dockerfile skipwhite nextgroup=jenkinsFileDockerConfigBlock
 syn keyword jenkinsfileCoreStep node
 syn keyword jenkinsfileCoreStep scm
 syn keyword jenkinsfileCoreStep sh
@@ -22,10 +22,10 @@ syn keyword jenkinsfileCoreStep step
 syn keyword jenkinsfileCoreStep tool
 
 " TODO: These should probably be broken out.
-syn keyword jenkinsfileCoreStep post always changed failure success unstable aborted
+syn keyword jenkinsfileCoreStep always changed failure success unstable aborted unsuccessful regression fixed cleanup
 
 syn region  jenkinsFileDockerConfigBlock contained start='{' end='}' contains=groovyString,jenkinsfileDockerKeyword transparent
-syn keyword jenkinsFileDockerKeyword contained image args dockerfile additionalBuildArgs
+syn keyword jenkinsFileDockerKeyword contained image args additionalBuildArgs label registryUrl registryCredentialsId alwaysPull filename dir
 
 syn keyword jenkinsfilePipelineStep Applitools ArtifactoryGradleBuild Consul MavenDescriptorStep OneSky VersionNumber
 syn keyword jenkinsfilePipelineStep ViolationsToBitbucketServer ViolationsToGitHub ViolationsToGitLab _OcAction _OcContextInit
@@ -110,8 +110,8 @@ syn keyword jenkinsfilePipelineStep walk waptProReport warnings whitesource winR
 syn keyword jenkinsfilePipelineStep withCredentials withDockerContainer withDockerRegistry withDockerServer withEnv withKafkaLog
 syn keyword jenkinsfilePipelineStep withKubeConfig withMaven withNPM withPod withPythonEnv withSCM withSandbox withSonarQubeEnv
 syn keyword jenkinsfilePipelineStep withTypetalk wrap writeFile writeJSON writeMavenPom writeProperties writeXml writeYaml
-syn keyword jenkinsfilePipelineStep ws xUnitImporter xUnitUploader xldCreatePackage xldDeploy xldPublishPackage xlrCreateRelease
-syn keyword jenkinsfilePipelineStep xrayScanBuild zip
+syn keyword jenkinsfilePipelineStep ws xUnitImporter xUnitUploader xunit xldCreatePackage xldDeploy xldPublishPackage
+syn keyword jenkinsfilePipelineStep xlrCreateRelease xrayScanBuild zip
 
 hi link jenkinsfileSection           Statement
 hi link jenkinsfileDirective         jenkinsfileSection


### PR DESCRIPTION
Added docker keywords and post conditions. Moved `post` to the same
level as other sections. Based on https://www.jenkins.io/doc/book/pipeline/syntax/, but the change doesn't cover each option listed there.

Also added xunit step.

Ideally steps sections needs to be synced with https://www.jenkins.io/doc/pipeline/steps/ from time to time.