### PR TITLE
Remove README section on compatibility issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,3 @@ Then fire up Vim and you're good to go.
 
 Alternatively, this is included in the [vim-polyglot package](https://github.com/sheerun/vim-polyglot),
 though polyglot may lag behind this repo by a version or two.
-
-## Compatibility issues
-
-The `vim-polyglot` Groovy highlighting is broken and using it is not recommended.
-It has been found to cause issues with this plugin (see [13](https://github.com/martinda/Jenkinsfile-vim-syntax/issues/13)).
-
-If you use `vim-polyglot`, your options are:
-
-* Nuke `vim-polyglot` and install `Jenkinsfile-vim-syntax` directly. This will use Vim's the built-in Groovy highlighting and the issue disappears.
-* File an issue with `vim-polyglot`. It uses [vim-scripts/groovy.vim](https://github.com/vim-scripts/groovy.vim) from 2004 for Groovy highlighting.


### PR DESCRIPTION
Good news! The issues are resolved!

@ftorres16 reported the outdated groovy syntax highlighting in vim-polyglot in https://github.com/sheerun/vim-polyglot/issues/456 and the outdated files were deleted in https://github.com/sheerun/vim-polyglot/commit/f77702c090d99e171250c906d54d75cb8e1306ee.

I installed the current version of vim-polyglot and verified that the example snippet gets syntax highlighted correctly.  The following code is good to go now:

```
post {
  always {
    sh '''
    echo "Tests generated"
    mv reports-python/* reports
    '''
  }
}
```