### PR TITLE
Syntax highlight new options

### DIFF
--- a/syntax/Jenkinsfile.vim
+++ b/syntax/Jenkinsfile.vim
@@ -7,6 +7,7 @@ syn keyword jenkinsfileDirective environment options parameters triggers stage t
 
 syn keyword jenkinsfileOption contained buildDiscarder disableConcurrentBuilds overrideIndexTriggers skipDefaultCheckout nextgroup=jenkinsfileOptionParams
 syn keyword jenkinsfileOption contained skipStagesAfterUnstable checkoutToSubdirectory timeout retry timestamps nextgroup=jenkinsfileOptionParams
+syn keyword jenkinsfileOption contained disableResume newContainerPerStage preserveStashes quietPeriod parallelsAlwaysFailFast nextgroup=jenkinsfileOptionParams
 syn region  jenkinsfileOptionParams contained start='(' end=')' transparent contains=@groovyTop
 syn match   jenkinsfileOptionO /[a-zA-Z]\+([^)]*)/ contains=jenkinsfileOption,jenkinsfileOptionParams transparent containedin=groovyParenT1
 


### PR DESCRIPTION
Now all pipeline-wide options listed at https://www.jenkins.io/doc/book/pipeline/syntax/#options are highlighted.

It'll be great if/when [INFRA-1053](https://issues.jenkins.io/browse/INFRA-1053) is completed, as that means we'll be able to sync what's highlighted with what's in Jenkins, but until then, a manual comparison with the latest documentation will work well enough.